### PR TITLE
build(docker): get Go modules before building img.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.18.3-alpine3.15
 WORKDIR /usr/src/app
 
 COPY ./api ./
-RUN go mod init && go build
+RUN go get fosshost/api fosshost/api/utils
+RUN go build
 
 CMD [ "./api" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18.3-alpine3.15
 WORKDIR /usr/src/app
 
 COPY ./api ./
-RUN go get fosshost/api fosshost/api/utils
+RUN go mod tidy
 RUN go build
 
 CMD [ "./api" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,5 @@ RUN go mod tidy
 RUN go build
 
 CMD [ "./api" ]
+
+EXPOSE 3000


### PR DESCRIPTION
When I tried to build the Docker image, I got this error:

```
Step 4/5 : RUN go mod init && go build
 ---> Running in 6dc491646657
go: /usr/src/app/go.mod already exists
The command '/bin/sh -c go mod init && go build' returned a non-zero code: 1
```

Removing the `go mod init` command solved this step, but then I ran into
another issue:

```
Step 4/5 : RUN go build
 ---> Running in 390d019a0f0f
api.go:14:2: missing go.sum entry for module providing package github.com/gofiber/fiber/v2 (imported by fosshost/api); to add:
        go get fosshost/api
api.go:15:2: missing go.sum entry for module providing package github.com/joho/godotenv (imported by fosshost/api); to add:
        go get fosshost/api
utils/utils.go:14:2: missing go.sum entry for module providing package go.mongodb.org/mongo-driver/bson (imported by fosshost/api/utils); to add:
        go get fosshost/api/utils
utils/utils.go:15:2: missing go.sum entry for module providing package go.mongodb.org/mongo-driver/mongo (imported by fosshost/api/utils); to add:
        go get fosshost/api/utils
utils/utils.go:16:2: missing go.sum entry for module providing package go.mongodb.org/mongo-driver/mongo/options (imported by fosshost/api/utils); to add:
        go get fosshost/api/utils
utils/utils.go:18:2: missing go.sum entry for module providing package go.uber.org/zap (imported by fosshost/api); to add:
        go get fosshost/api
The command '/bin/sh -c go build' returned a non-zero code: 1
```

I then added `RUN go get fosshost/api fosshost/api/utils` before `RUN go
build`, which seems to solve the issue.