### PR TITLE
chore: remove api/api Go binary added by mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ provisioning/*.retry
 __pycache__/
 go.sum
 go.work.sum
+api/api
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ provisioning/*.retry
 __pycache__/
 go.sum
 go.work.sum
-api/api
+/api/api
 .env


### PR DESCRIPTION
The 18-megabyte API binary seems to have been included by mistake, so I removed it. I also added `api/api` to the `.gitignore` file to prevent this from happening again.